### PR TITLE
move the gettting started section around

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'BioKEM'
-copyright = '2021, Shawn Laursen'
+copyright = '2022, Shawn Laursen'
 author = 'Shawn Laursen'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/source/getting.rst
+++ b/docs/source/getting.rst
@@ -5,8 +5,8 @@ Getting your data
    :width: 300
    :align: right
 
-Push to Petalibrary **Preferred**
----------------------------------
+Push to Petalibrary (*Preferred method*)
+----------------------------------------
 The preferred method of getting your data from the BioKEM facility is to have us push
 it to your `biokem-deposit` folder. We can do this in real time so you can start 
 processing data as it comes off the scope (we can also do 
@@ -46,8 +46,8 @@ to a server your lab owns on CU's network. Once Chuck sets you up with a user
 account on the biokem-storage server you will be able to use an ``rsync`` command
 to transfer your data to your server from the ``Interm storage`` partition.
 
-External hard drive **Discouraged**
------------------------------------
+External hard drive (*Discouraged method*)
+------------------------------------------
 Transferring data via physically transporting an external hard drive is discouraged,
 as these disks are non-redundant, slow, and prone to physical damage. If none of
 the other methods are available to you however; you may drop off a hard drive to

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,9 +19,9 @@ Camera. You are likely looking for :doc:`/processing/how_to`.
 
    faqs
    collecting
-   processing
-   storing
    getting
+   storing
+   processing
    external_links
 
 For addition technical help please contact Chuck Moe (charles.moe@colorado.edu). For 

--- a/docs/source/processing.rst
+++ b/docs/source/processing.rst
@@ -4,7 +4,7 @@ Processing data
 The BioKEM computing environment consists of three main parts: Petalibrary, 
 Blanca, and SBGrid. In order to use the cluster, you will need to gain access to 
 all three of these resources (see :doc:`processing/how_to`). In brief, you will
-host your dataset on Petalibrary, process it on nodes within the Blanca 
+host your dataset on Petalibrary and process it on nodes within the Blanca 
 computing cluster using software managed through SBGrid.
 
 .. image:: images/schematic.png

--- a/docs/source/processing/ccet_users.rst
+++ b/docs/source/processing/ccet_users.rst
@@ -1,0 +1,8 @@
+CCET users
+==========
+
+The Center for Cryo Electron Tomography (CCET) owns one of the nodes in the blanca-biokem cluster. Users from CCET can access this and other nodes in the blanca-biokem 
+and blanca clusters by obtaining a guest account and following the general instructions.
+
+To acquire a guest account you will need to go through the `Sponsored Affiliates <https://oit.colorado.edu/accounts/sponsored-affiliates>`_ processes.
+After you acquire an account, have your CCET contact send an email to rc-help@colorado.edu to get added to the CCET group on Blanca. 

--- a/docs/source/processing/getting_started.rst
+++ b/docs/source/processing/getting_started.rst
@@ -1,0 +1,19 @@
+Getting started
+===============
+
+In order to run software on BioKEM's Blanca servers:
+   #. Request a Research Computing account with access to Blanca through `Research Computing <https://rcamp.rc.colorado.edu/accounts/account-request/create/organization>`_
+   #. Set up a Petalibrary allocation (~20TB/active project) by emailing rc-help@colorado.edu **Make sure to have them create a 'biokem-deposit' folder for your lab to deposit Krios images into**
+   #. Purchase an SBGrid license for your lab
+
+      - Labs without an SBGrid license will have minimal access to software.
+      - Labs with their own SBGrid license will be able to access the full stack of software, without limitation.
+
+   #. In order to be given access to BioKEM owned nodes and software, you must complete three training courses provided by CURC (check scheduling here: `CURC Events and Training <https://www.colorado.edu/rc/events>`_):
+
+       - RC New User Seminar 
+       - Super Computing Spin Up: Part 1 - Working with Linux
+       - Super Computing Spin Up: Part 2 – Job Scheduling 
+ 
+   #. Send reciept of completion of the three RC courses above to the BioKEM cluster administrator (`shla9937@colorado.edu`_) to be added to the BioKEM parition. 
+   #. Start running jobs as outlined here (insert link) 

--- a/docs/source/processing/how_to.rst
+++ b/docs/source/processing/how_to.rst
@@ -1,52 +1,12 @@
 How to use blanca-biokem
 ========================
 
-Getting started
----------------
-In order to run software on BioKEM's Blanca servers:
-   - Request access to Blanca through `Research Computing <https://rcamp.rc.colorado.edu/accounts/account-request/create/organization>`_
-   - Request a Petalibrary allocation (~20TB/active project) by emailing rc-help@colorado.edu **Make sure to have them create a 'biokem-deposit' folder for your lab to deposit Krios images into**
-   - Purchase an SBGrid license for your lab
+To use BioKEM's nodes and software stack on Blanca first complete the list of tasks in the :doc:`getting_started` section (If you are a CCET member, first see :doc:`ccet_users`). Once, you have done this, move onto :doc:`using_software`.   
 
-     - Labs without an SBgrid license will have minimal access to software.
-     - Labs with their own SBgrid license will be able to access the full stack of software, without limitation.
+.. toctree::
+   :maxdepth: 2
 
+   getting_started
+   using_software
+   ccet_users
 
-CCET users
-----------
-
-The Center for Cryo Electron Tomography (CCET) owns one of the nodes in the blanca-biokem cluster. Users from CCET can access this and other nodes in the blanca-biokem 
-and blanca clusters by obtaining a guest account and following the general instructions.
-
-Acquiring a guest account
--------------------------
-
-To acquire a guest account you will need to go through the `Sponsored Affiliates <https://oit.colorado.edu/accounts/sponsored-affiliates>`_ processes.
-After you acquire an account, have your CCET contact send an email to rc-help@colorado.edu to get added to the CCET group on Blanca. 
-
-Using software
---------------
-
-*You may need to submit a help ticket to gain access to EnginFrame.*
-
-#. Log onto onto CU's VPN (`setup through OIT <https://oit.colorado.edu/vpn-virtual-private-network>`_)
-#. Access blanca through the `EnginFrame <https://viz.rc.colorado.edu/enginframe/demo/index.html>`_ portal.
-#. Click on ``Views``
-#. Login with your identikey
-#. Accept DUO Mobile push on your phone
-#. Start a ``Remote Desktop`` session
-#. Selected the desired number of CPUs (2 is usually fine), click ``Launch Session``
-#. (may need to click on the thumbnail) Once in the remote desktop, click on the terminal icon on the menu bar
-#. You are now on the viz node, which will be fine for applications like ChimeraX, but most of the time you'll want to be on a login node.
-#. To get to a login node ``ssh -Y login10`` (can use 10-13, but this ssh requires a specific node number)
-#. Enter password and accept DUO Mobile push
-#. Now you can load the blanca envirnoment ``ml slurm/blanca``
-#. The first time you log into blanca:
-   
-   - ``echo 'export MODULEPATH=/projects/biokem/modules:/programs/share/modulefiles/x86_64-linux:"$MODULEPATH"' >> ~/.bashrc``
-   - ``source ~/.bashrc``
-
-#. You should now be able to run ``ml avail`` and see a few new modules
-#. To see all the modules available, you need to log onto a compute node interactively: ``sinteractive --qos=blanca-biokem --account=blanca-biokem --partition=blanca-biokem --ntasks=1``
-#. From here you can troubleshoot software (you may need to request more resources)
-#. To actually run software submit an sbatch job (RELION and CryoSPARC have GUIs that allow you to do this interactively)

--- a/docs/source/processing/using_software.rst
+++ b/docs/source/processing/using_software.rst
@@ -1,0 +1,26 @@
+Using software
+==============
+
+*You may need to submit a help ticket to gain access to EnginFrame.*
+
+#. Log onto onto CU's VPN (`setup through OIT <https://oit.colorado.edu/vpn-virtual-private-network>`_)
+#. Access blanca through the `EnginFrame <https://viz.rc.colorado.edu/enginframe/demo/index.html>`_ portal.
+#. Click on ``Views``
+#. Login with your identikey
+#. Accept DUO Mobile push on your phone
+#. Start a ``Remote Desktop`` session
+#. Selected the desired number of CPUs (2 is usually fine), click ``Launch Session``
+#. (may need to click on the thumbnail) Once in the remote desktop, click on the terminal icon on the menu bar
+#. You are now on the viz node, which will be fine for applications like ChimeraX, but most of the time you'll want to be on a login node.
+#. To get to a login node ``ssh -Y login10`` (can use 10-13, but this ssh requires a specific node number)
+#. Enter password and accept DUO Mobile push
+#. Now you can load the blanca envirnoment ``ml slurm/blanca``
+#. The first time you log into blanca:
+   
+   - ``echo 'export MODULEPATH=/projects/biokem/modules:/programs/share/modulefiles/x86_64-linux:"$MODULEPATH"' >> ~/.bashrc``
+   - ``source ~/.bashrc``
+
+#. You should now be able to run ``ml avail`` and see a few new modules
+#. To see all the modules available, you need to log onto a compute node interactively: ``sinteractive --qos=blanca-biokem --account=blanca-biokem --partition=blanca-biokem --ntasks=1``
+#. From here you can troubleshoot software (you may need to request more resources)
+#. To actually run software submit an sbatch job (RELION and CryoSPARC have GUIs that allow you to do this interactively)


### PR DESCRIPTION
Had to open a separate branch because it looks like someone made a CryoEM training file, which I don't have on my local main branch. Probably could have just pulled and nothing would have happened. 